### PR TITLE
Added int casts, to fix compilation incompletion.

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -668,12 +668,12 @@ FC_Rect FC_DefaultRenderCallback(FC_Image* src, FC_Rect* srcrect, FC_Target* des
         if(xscale < 0)
         {
             xscale = -xscale;
-            flip = flip | SDL_FLIP_HORIZONTAL;
+            flip = (SDL_RendererFlip) ((int)flip | (int)SDL_FLIP_HORIZONTAL);
         }
         if(yscale < 0)
         {
             yscale = -yscale;
-            flip = flip | SDL_FLIP_VERTICAL;
+            flip = (SDL_RendererFlip) ((int)flip | (int)SDL_FLIP_VERTICAL);
         }
         
         SDL_Rect r = *srcrect;


### PR DESCRIPTION
Object was failing to compile on function FC_DefaultRenderCallback
because the binary or was resulting in an int instead of the enum type
of SDL_RendererFlip.
