### PR TITLE
Avoiding one time leaks at shutdown

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -162,44 +162,50 @@ static unsigned int fc_buffer_size = 1024;
 
 static Uint8 fc_has_render_target_support = 0;
 
+// The number of fonts that has been created but not freed
+static int NUM_EXISTING_FONTS = 0;
+
+// Globals for GetString functions
+static char* ASCII_STRING = NULL;
+static char* LATIN_1_STRING = NULL;
+static char* ASCII_LATIN_1_STRING = NULL;
+
 char* FC_GetStringASCII(void)
 {
-    static char* buffer = NULL;
-    if(buffer == NULL)
+    if(ASCII_STRING == NULL)
     {
         int i;
         char c;
-        buffer = (char*)malloc(512);
-        memset(buffer, 0, 512);
+        ASCII_STRING = (char*)malloc(512);
+        memset(ASCII_STRING, 0, 512);
         i = 0;
         c = 32;
         while(1)
         {
-            buffer[i] = c;
+            ASCII_STRING[i] = c;
             if(c == 126)
                 break;
             ++i;
             ++c;
         }
     }
-    return U8_strdup(buffer);
+    return U8_strdup(ASCII_STRING);
 }
 
 char* FC_GetStringLatin1(void)
 {
-    static char* buffer = NULL;
-    if(buffer == NULL)
+    if(LATIN_1_STRING == NULL)
     {
         int i;
         unsigned char c;
-        buffer = (char*)malloc(512);
-        memset(buffer, 0, 512);
+        LATIN_1_STRING = (char*)malloc(512);
+        memset(LATIN_1_STRING, 0, 512);
         i = 0;
         c = 0xA0;
         while(1)
         {
-            buffer[i] = 0xC2;
-            buffer[i+1] = c;
+            LATIN_1_STRING[i] = 0xC2;
+            LATIN_1_STRING[i+1] = c;
             if(c == 0xBF)
                 break;
             i += 2;
@@ -209,24 +215,23 @@ char* FC_GetStringLatin1(void)
         c = 0x80;
         while(1)
         {
-            buffer[i] = 0xC3;
-            buffer[i+1] = c;
+            LATIN_1_STRING[i] = 0xC3;
+            LATIN_1_STRING[i+1] = c;
             if(c == 0xBF)
                 break;
             i += 2;
             ++c;
         }
     }
-    return U8_strdup(buffer);
+    return U8_strdup(LATIN_1_STRING);
 }
 
 char* FC_GetStringASCII_Latin1(void)
 {
-    static char* buffer = NULL;
-    if(buffer == NULL)
-        buffer = new_concat(FC_GetStringASCII(), FC_GetStringLatin1());
+    if(ASCII_LATIN_1_STRING == NULL)
+		ASCII_LATIN_1_STRING = new_concat(FC_GetStringASCII(), FC_GetStringLatin1());
 
-    return U8_strdup(buffer);
+    return U8_strdup(ASCII_LATIN_1_STRING);
 }
 
 FC_Rect FC_MakeRect(float x, float y, float w, float h)
@@ -1063,6 +1068,7 @@ FC_Font* FC_CreateFont(void)
     memset(font, 0, sizeof(FC_Font));
 
     FC_Init(font);
+    ++NUM_EXISTING_FONTS;
 
     return font;
 }
@@ -1337,6 +1343,22 @@ void FC_FreeFont(FC_Font* font)
     free(font->loading_string);
 
     free(font);
+
+    // If the last font has been freed; assume shutdown and free the global variables
+    if (--NUM_EXISTING_FONTS <= 0)
+    {
+        free(ASCII_STRING);
+        ASCII_STRING = NULL;
+
+        free(LATIN_1_STRING);
+        LATIN_1_STRING = NULL;
+
+        free(ASCII_LATIN_1_STRING);
+        ASCII_LATIN_1_STRING = NULL;
+
+        free(fc_buffer);
+        fc_buffer = NULL;
+    }
 }
 
 int FC_GetNumCacheLevels(FC_Font* font)

--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -2289,7 +2289,7 @@ Uint16 FC_GetLineHeight(FC_Font* font)
 
 Uint16 FC_GetHeight(FC_Font* font, const char* formatted_text, ...)
 {
-    if(formatted_text == NULL || font == NULL)
+    if(formatted_text == NULL || font == NULL || formatted_text[0] == '\0')
         return 0;
 
     FC_EXTRACT_VARARGS(fc_buffer, formatted_text);
@@ -2309,7 +2309,7 @@ Uint16 FC_GetHeight(FC_Font* font, const char* formatted_text, ...)
 
 Uint16 FC_GetWidth(FC_Font* font, const char* formatted_text, ...)
 {
-    if(formatted_text == NULL || font == NULL)
+    if(formatted_text == NULL || font == NULL || formatted_text[0] == '\0')
         return 0;
 
     FC_EXTRACT_VARARGS(fc_buffer, formatted_text);


### PR DESCRIPTION
This shouldn't affect performance as long as the application doesn't call FC_CreateFont and FC_FreeFont() every frame.