### PR TITLE
FC_GetHeight of empty string= 0

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -2267,7 +2267,7 @@ Uint16 FC_GetLineHeight(FC_Font* font)
 
 Uint16 FC_GetHeight(FC_Font* font, const char* formatted_text, ...)
 {
-    if(formatted_text == NULL || font == NULL)
+    if(formatted_text == NULL || font == NULL || formatted_text[0] == '\0')
         return 0;
 
     FC_EXTRACT_VARARGS(fc_buffer, formatted_text);
@@ -2287,7 +2287,7 @@ Uint16 FC_GetHeight(FC_Font* font, const char* formatted_text, ...)
 
 Uint16 FC_GetWidth(FC_Font* font, const char* formatted_text, ...)
 {
-    if(formatted_text == NULL || font == NULL)
+    if(formatted_text == NULL || font == NULL || formatted_text[0] == '\0')
         return 0;
 
     FC_EXTRACT_VARARGS(fc_buffer, formatted_text);


### PR DESCRIPTION
Previous to this commit FC_GetHeight returned the line height if it was supplied with an empty string. It will now return 0 in this case.

If you prefer to check against empty string in some other way I can change it. I mostly work with C++ so I'm not sure if this is the go-to way of checking against empty string in C.

I also ran the test and it was unaffected.