### PR TITLE
Added null check

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -1639,8 +1639,13 @@ void FC_StringListFree(FC_StringList* node)
 
 FC_StringList** FC_StringListPushBack(FC_StringList** node, char* value, Uint8 copy)
 {
+    if(node == NULL)
+    {
+        return node;
+    }
+    
     // Get to the last node
-    while(node != NULL && *node != NULL)
+    while(*node != NULL)
     {
         node = &(*node)->next;
     }
@@ -2632,9 +2637,3 @@ void FC_SetDefaultColor(FC_Font* font, SDL_Color color)
 
     font->default_color = color;
 }
-
-
-
-
-
-


### PR DESCRIPTION
The line
```
*node = (FC_StringList*)malloc(sizeof(FC_StringList));
```
Will cause undefined behaviour if "node" is NULL. 
However right before it was a while loop like this:
```
while(node != NULL && *node != NULL)
    {
        node = &(*node)->next;
    }
```
Indicating that "node" could be NULL.
This caused Codacy to complain.

This pull requests adds a NULL check that will prevent the program from reaching the code that would trigger an undefined behaviour.