### PR TITLE
patch for custom loading string and FC_GrowGlyphCache

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -1160,10 +1160,10 @@ Uint8 FC_LoadFontFromTTF(FC_Font* font, SDL_Renderer* renderer, TTF_Font* ttf, S
         font->last_glyph.rect.w = 0;
         font->last_glyph.rect.h = font->height;
 
-        memset(buff, 0, 5);
         source_string = font->loading_string;
         for(; *source_string != '\0'; source_string = U8_next(source_string))
         {
+            memset(buff, 0, 5);
             if(!U8_charcpy(buff, source_string, 5))
                 continue;
             glyph_surf = TTF_RenderUTF8_Blended(ttf, buff, white);

--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -549,10 +549,11 @@ const char* U8_next(const char* string)
 
 int U8_strinsert(char* string, int position, const char* source, int max_bytes)
 {
-    int pos_bytes;
+    int pos_u8char;
     int len;
     int add_len;
     int ulen;
+    const char* string_start = string;
 
     if(string == NULL || source == NULL)
         return 0;
@@ -568,15 +569,15 @@ int U8_strinsert(char* string, int position, const char* source, int max_bytes)
         return 0;
 
     // Move string pointer to the proper position
-    pos_bytes = 0;
-    while(*string != '\0' && pos_bytes < position)
+    pos_u8char = 0;
+    while(*string != '\0' && pos_u8char < position)
     {
         string = (char*)U8_next(string);
-        ++pos_bytes;
+        ++pos_u8char;
     }
 
     // Move the rest of the string out of the way
-    memmove(string + add_len, string, len - pos_bytes + 1);
+    memmove(string + add_len, string, len - (string - string_start) + 1);
 
     // Copy in the new characters
     memcpy(string, source, add_len);

--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -1306,6 +1306,35 @@ Uint8 FC_LoadFont_RW(FC_Font* font, FC_Target* renderer, SDL_RWops* file_rwops_t
 }
 
 
+#ifndef FC_USE_SDL_GPU
+void FC_ResetFontFromRendererReset(FC_Font* font, SDL_Renderer* renderer, Uint32 evType)
+{
+    TTF_Font* ttf;
+    SDL_Color col;
+    Uint8 owns_ttf;
+    if (font == NULL)
+        return;
+
+    // Destroy glyph cache
+    if (evType == SDL_RENDER_TARGETS_RESET) {
+        int i;
+        for (i = 0; i < font->glyph_cache_count; ++i)
+            SDL_DestroyTexture(font->glyph_cache[i]);
+    }
+    free(font->glyph_cache);
+
+    ttf = font->ttf_source;
+    col = font->default_color;
+    owns_ttf = font->owns_ttf_source;
+    FC_Init(font);
+
+    // Can only reload glyphs if we own the SDL_RWops.
+    if (owns_ttf)
+        FC_LoadFontFromTTF(font, renderer, ttf, col);
+    font->owns_ttf_source = owns_ttf;
+}
+#endif
+
 void FC_ClearFont(FC_Font* font)
 {
     int i;

--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -907,6 +907,10 @@ static Uint8 FC_GrowGlyphCache(FC_Font* font)
         #endif
         return 0;
     }
+    // bug: we do not have the correct color here, this might be the wrong color!
+    //      , most functions use set_color_for_all_caches()
+    //   - for evading this bug, you must use FC_SetDefaultColor(), before using any draw functions
+    set_color(new_level, font->default_color.r, font->default_color.g, font->default_color.b, FC_GET_ALPHA(font->default_color));
 #ifndef FC_USE_SDL_GPU
     {
         Uint8 r, g, b, a;

--- a/SDL_FontCache.h
+++ b/SDL_FontCache.h
@@ -143,6 +143,11 @@ Uint8 FC_LoadFontFromTTF(FC_Font* font, SDL_Renderer* renderer, TTF_Font* ttf, S
 Uint8 FC_LoadFont_RW(FC_Font* font, SDL_Renderer* renderer, SDL_RWops* file_rwops_ttf, Uint8 own_rwops, Uint32 pointSize, SDL_Color color, int style);
 #endif
 
+#ifndef FC_USE_SDL_GPU
+// note: handle SDL event types SDL_RENDER_TARGETS_RESET(>= SDL 2.0.2) and SDL_RENDER_DEVICE_RESET(>= SDL 2.0.4)
+void FC_ResetFontFromRendererReset(FC_Font* font, SDL_Renderer* renderer, Uint32 evType);
+#endif
+
 void FC_ClearFont(FC_Font* font);
 
 void FC_FreeFont(FC_Font* font);


### PR DESCRIPTION
fix custom loading string
fix for FC_GrowGlyphCache
handler for event types SDL_RENDER_TARGETS_RESET(>= SDL 2.0.2) and SDL_RENDER_DEVICE_RESET(>= SDL 2.0.4)