### PR TITLE
Fix vertical spacing between lines when rendering scaled text. Fixes issue #40.

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -2018,7 +2018,7 @@ static void FC_DrawColumnFromBuffer(FC_Font* font, FC_Target* dest, FC_Rect box,
     for(iter = ls; iter != NULL; iter = iter->next)
     {
         FC_RenderAlign(font, dest, box.x, y, box.w, scale, align, iter->value);
-        y += FC_GetLineHeight(font);
+        y += FC_GetLineHeight(font) * scale.y;
     }
     FC_StringListFree(ls);
 


### PR DESCRIPTION
Fixes: #40 