### PR TITLE
Fix crashing when SDL_HINT_RENDER_SCALE_QUALITY has no previous value

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -984,7 +984,10 @@ Uint8 FC_UploadGlyphCache(FC_Font* font, int cache_level, SDL_Surface* data_surf
 
         // Set filter mode for new texture
         char old_filter_mode[16];  // Save it so we can change the hint value in the meantime
-        snprintf(old_filter_mode, 16, "%s", SDL_GetHint(SDL_HINT_RENDER_SCALE_QUALITY));
+        const char* old_filter_hint = SDL_GetHint(SDL_HINT_RENDER_SCALE_QUALITY);
+        if(!old_filter_hint)
+            old_filter_hint = "nearest";
+        snprintf(old_filter_mode, 16, "%s", old_filter_hint);
 
         if(FC_GetFilterMode(font) == FC_FILTER_LINEAR)
             SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");


### PR DESCRIPTION
It's possible for hints in SDL to have no value, and if that's the case, `SDL_GetHint()` will return NULL. `FC_UploadGlyphCache` didn't handle this case and instead passed the NULL to `snprintf()` which made it crash on my target system.

~~I modified the function to check the obtained pointer first, and only execute the `snprintf` (and the later hint-resetting) if that pointer isn't NULL. This fixed the crash for me.~~
I modified the function to check the obtained pointer first, and if it is NULL, it gets set to the string constant "nearest" instead. This fixed the crash for me.