### PR TITLE
Support for scaling during drawn boxed text

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -1962,6 +1962,7 @@ static void FC_RenderAlign(FC_Font* font, FC_Target* dest, float x, float y, int
 
 static FC_StringList* FC_GetBufferFitToColumn(FC_Font* font, int width, FC_Scale scale, Uint8 keep_newlines)
 {
+    width = (int)(width / scale.x);
     FC_StringList* result = NULL;
     FC_StringList** current = &result;
 
@@ -2021,7 +2022,7 @@ static void FC_DrawColumnFromBuffer(FC_Font* font, FC_Target* dest, FC_Rect box,
     for(iter = ls; iter != NULL; iter = iter->next)
     {
         FC_RenderAlign(font, dest, box.x, y, box.w, scale, align, iter->value);
-        y += FC_GetLineHeight(font);
+        y += FC_GetLineHeight(font)*scale.y;
     }
     FC_StringListFree(ls);
 


### PR DESCRIPTION
When mixing drawBox with scale, text does not wrap up correctly

This happens because FC_GetBufferFitToColumn takes scale as a parameter but does not actually scale anything. I solved this problem by adding 

width = (int)(width / scale.x);

To the beginning of FC_GetBufferFitToColumn.
There is also a similar problem of scale not being taken into account on the line distance. I fixed it by changing 
y += FC_GetLineHeight(font);
to
y += FC_GetLineHeight(font)*scale.y;