### PR TITLE
Modify new_concat

### DIFF
--- a/SDL_FontCache.c
+++ b/SDL_FontCache.c
@@ -134,15 +134,16 @@ static void set_color(FC_Image* src, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 static char* new_concat(const char* a, const char* b)
 {
     // Create new buffer
-    unsigned int size = strlen(a) + strlen(b);
-    char* new_string = (char*)malloc(size+1);
+    unsigned int len_a = strlen(a);
+    char* new_string = (char*)malloc(len_a + strlen(b) + 1);
 
     // Concatenate strings in the new buffer
     strcpy(new_string, a);
-    strcat(new_string, b);
+    strcpy(new_string + len_a, b);
 
     return new_string;
 }
+
 
 static char* replace_concat(char** a, const char* b)
 {


### PR DESCRIPTION
Changed new_concat, line 134, to use two strcpy instead of strcpy and strcat.

Since the length of const char *a is computed once to figure out the malloc of char *new_string it can be stored
and used to offset new_string instead of having strcat recompute the length of const char *a.